### PR TITLE
Put map name into <title> of map page

### DIFF
--- a/views/map.ejs
+++ b/views/map.ejs
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
 		<link rel="stylesheet" type="text/css" href="/css/map.css">
 
-		<title>Fortunate Maps - Map</title>
+		<title><%- map.name %></b> by <b><%- map.authorName %></title>
 	</head>
 	<body>
 		<%- include('nav'); %>


### PR DESCRIPTION
It's frustrating that all map pages have the same title. Navigating with multiple tabs open becomes impossible.